### PR TITLE
Add client-complete-pending-command method.

### DIFF
--- a/test/miner/ftp_test.clj
+++ b/test/miner/ftp_test.clj
@@ -43,6 +43,18 @@
       (is (instance? java.io.InputStream
                      (client-get-stream client "README.olderversions"))))))
 
+(deftest get-stream-client-two-files
+  (let [tmp (fs/temp-file "ftp-")]
+    (with-ftp [client "ftp://anonymous:user%40example.com@ftp.gnu.org/gnu/emacs"]
+      (with-open [s1 (client-get-stream client "README.olderversions")]
+        (is (instance? java.io.InputStream s1))
+        (io/copy s1 tmp)
+        (client-complete-pending-command client))
+      (with-open [s2 (client-get-stream client "README.olderversions")]
+        (is (instance? java.io.InputStream s2))
+        (io/copy s2 tmp)
+        (client-complete-pending-command client)))))
+
 (deftest get-filenames
   (with-ftp [client "ftp://anonymous:user%40example.com@ftp.gnu.org/gnu/emacs"]
     (is (client-file-names client) (client-list-files client))))


### PR DESCRIPTION
For certain FTP commands it's necessary to do more work to complete a transaction. In my case I was GET-ing multiple files in the same session using `client-get-stream`. The second call to `client-get-stream` returns a nil stream and a reply code of `226 - TRANSFER COMPLETED`. This is the final response from the previous FTP command. This should have been retrieved with a further command before proceeding to the next GET. There is no way to do this currently in clj-ftp.

This Pull Request adds a wrapper around `client-complete-pending command` and
a test proving that it's needed when downloading multiple files. I suspect other FTP commands should use this too, but I haven't come across them (yet)

See [Here for details](http://commons.apache.org/proper/commons-net/apidocs/org/apache/commons/net/ftp/FTPClient.html#completePendingCommand%28%29)
