### PR TITLE
Support ftps as ftp client protocol

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.velisco/clj-ftp "0.3.2"
+(defproject com.velisco/clj-ftp "0.3.3-SNAPSHOT"
   :description "Clojure wrapper on Apache Commons Net for FTP"
   :url "http://github.com/miner/clj-ftp"
   :license {:name "Eclipse Public License"
@@ -6,7 +6,8 @@
   :min-lein-version "2.0"
   :dependencies [[org.clojure/clojure "1.4.0"]
                  [me.raynes/fs "1.4.6"]
-                 [commons-net "3.3"]]
+                 [commons-net "3.3"]
+                 [clojurewerkz/urly "1.0.0"]]
   :profiles {:test {:resource-paths ["test-resources"]
                     :dependencies [[digest "1.4.4"]]}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}})

--- a/src/miner/ftp.clj
+++ b/src/miner/ftp.clj
@@ -13,14 +13,15 @@
 (ns miner.ftp
   (:import [org.apache.commons.net.ftp FTP FTPClient FTPSClient FTPFile FTPReply]
            [java.net URL URLDecoder]
-           [java.io File IOException])
+           [java.io File IOException]
+           [clojurewerkz.urly UrlLike])
   (:require [me.raynes.fs :as fs]
             [clojure.string :as str]
             [clojure.java.io :as io]
             [clojurewerkz.urly.core :as urly]))
 
 (defn open [url]
-  (let [url (urly/url-like url)
+  (let [^UrlLike url (urly/url-like url)
         ^FTPClient client (case (.getProtocol url)
                             "ftp" (FTPClient.)
                             "ftps" (FTPSClient.)
@@ -83,7 +84,7 @@
                        control-keep-alive-reply-timeout-ms 1000}}] & body]
   `(let [local-mode# ~local-data-connection-mode
          u# (urly/url-like ~url)
-         ~client (open u#)
+         ~client ^FTPClient (open u#)
          file-type# ~file-type]
      (when ~client
        (try


### PR DESCRIPTION
This change implements ftps as additional protocol to ftp.  This required using the https://github.com/michaelklishin/urly library instead of the bare URL class as the latter does not support ftps as protocol out of the box, and adding protocol handlers to the JVM is a very involved process which is not actually necessary in clj-ftp, as it uses the URL class only to parse the URL into components (which is what urly does as well).