### PR TITLE
Only change directory if one has been specified

### DIFF
--- a/src/miner/ftp.clj
+++ b/src/miner/ftp.clj
@@ -91,7 +91,10 @@
          (when-let [user-info# (.getUserInfo u#)]
            (let [[uname# pass#] (.split user-info# ":" 2)]
              (.login ~client (decode uname#) (decode pass#))))
-         (.changeWorkingDirectory ~client (.getPath u#))
+         (let [path# (.getPath u#)]
+           (when (and path#
+                      (not= path# "/"))
+             (.changeWorkingDirectory ~client (subs path# 1))))
          (client-set-file-type ~client file-type#)
          (.setDataTimeout ~client ~data-timeout-ms)
          (.setControlKeepAliveTimeout ~client ~control-keep-alive-timeout-sec)


### PR DESCRIPTION
Previously, with-ftp would always change the working directory, even
if the path component of the URL was empty or "/".  The first slash
after the host name needs to be considered a separator and not part of
the directory name of the remote, though, and the urly library always
normalizes URL strings contain at least "/" as path.  With this
change, with-ftp will only attempt to change the directory if a path
component is present in the URL and it is not "/".  It will also strip
the first slash to make the path relative to the current directly.

Thus:

ftp://example.com => no chdir
ftp://example.com/ => no chdir
ftp://example.com/foo => chdir to "foo"
ftp://example.com//foo => chdir to "/foo"