### PR TITLE
Add connection timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ FTP servers and situations where security is not an issue.
 
     (ftp/with-ftp [client "ftp://anonymous:pwd@ftp.example.com/pub"]
 		(ftp/client-get client "interesting.txt" "stuff.txt"))
-		
+
 By default, we use a passive local data connection.  You can override that by passing an option
 after the URL.  Use :local-data-connection-mode :active if you don't want passive mode.  For
 example:
 
-    (ftp/with-ftp [client "ftp://anonymous:pwd@ftp.example.com/pub" 
+    (ftp/with-ftp [client "ftp://anonymous:pwd@ftp.example.com/pub"
 	               :local-data-connection-mode :active]
 		(ftp/client-get client "interesting.txt" "stuff.txt"))
 
@@ -36,6 +36,7 @@ The default file-type for transfers is :ascii, but you can change it with the op
 :binary` in `with-ftp`.  Use `client-set-file-type` to set it appropriately before each transfer.
 
 The options for `with-ftp` are:
+- `:connect-timeout-ms` (default to 30000)
 - `:data-timeout-ms` (default infinite)
 - `:control-keep-alive-timeout-sec` (default 300)
 - `:control-keep-alive-reply-timeout-ms` (default 1000)

--- a/test/miner/ftp_test.clj
+++ b/test/miner/ftp_test.clj
@@ -39,6 +39,10 @@
     (when (fs/exists? tmp2)
       (fs/delete tmp2))))
 
+(deftest set-connect-timeout
+  (let [url "ftp://anonymous@google.com:81"]
+    (is (thrown? java.io.IOException (open url "UTF-8" {:connect-timeout-ms 1})))))
+
 (deftest get-stream-client
   (let [tmp (fs/temp-file "ftp-")]
     (with-ftp [client "ftp://anonymous:user%40example.com@ftp.gnu.org/gnu/emacs"]


### PR DESCRIPTION
Hi,

Sorry for the late PR this fixes #27 .

We are setting the connect timeout and also we have moved the data timeout before we make a connection. 

I have changed to use the fully qualified class name for java.net.URI in the type hint as it throws an exception when running with clojure < 1.8, probably due to this: https://dev.clojure.org/jira/browse/CLJ-1232

Let me know if there's anything you would like me to change or add

Thanks

andrea