### PR TITLE
Allow setting default timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The default file-type for transfers is :ascii, but you can change it with the op
 :binary` in `with-ftp`.  Use `client-set-file-type` to set it appropriately before each transfer.
 
 The options for `with-ftp` are:
+- `:default-timeout-ms` (not set by default)
 - `:connect-timeout-ms` (default to 30000)
 - `:data-timeout-ms` (default infinite)
 - `:control-keep-alive-timeout-sec` (default 300)

--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,7 @@
                  [me.raynes/fs "1.4.6"]
                  [commons-net "3.6"]]
   :profiles {:test {:resource-paths ["test-resources"]
-                    :dependencies [[digest "1.4.5"]]} })
+                    :dependencies [[org.mockftpserver/MockFtpServer "2.0.2"]
+                                   [digest "1.4.5"]]}})
 
 

--- a/resources/log4j.properties
+++ b/resources/log4j.properties
@@ -1,0 +1,5 @@
+log4j.rootLogger=WARN, A1
+
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n

--- a/src/miner/ftp.clj
+++ b/src/miner/ftp.clj
@@ -27,6 +27,7 @@
   ([url control-encoding
     {:keys [data-timeout-ms
             connect-timeout-ms
+            default-timeout-ms
             control-keep-alive-timeout-sec
             control-keep-alive-reply-timeout-ms]
      :or {data-timeout-ms -1
@@ -39,6 +40,7 @@
                              "ftps" (FTPSClient.)
                              (throw (Exception. (str "unexpected protocol " (.getScheme uri) " in FTP url, need \"ftp\" or \"ftps\""))))]
      ;; (.setAutodetectUTF8 client true)
+     (when default-timeout-ms (.setDefaultTimeout client default-timeout-ms))
      (.setControlEncoding client control-encoding)
      (.setConnectTimeout client connect-timeout-ms)
      (.setDataTimeout client data-timeout-ms)

--- a/test/miner/ftp_test.clj
+++ b/test/miner/ftp_test.clj
@@ -3,7 +3,8 @@
         miner.ftp)
   (:require [me.raynes.fs :as fs]
             [digest :as dig]
-            [clojure.java.io :as io])
+            [clojure.java.io :as io]
+            [miner.mock-ftp :as mock-ftp])
   (:import (org.apache.commons.net.ftp FTPFile)))
 
 (deftest listing
@@ -179,3 +180,11 @@
     ["foo+++" "baz"]       "ftp://foo+++:baz@example.com"
 
     ["çåƒé" "ßåßê"]        "ftp://%c3%a7%c3%a5%c6%92%c3%a9:%c3%9f%c3%a5%c3%9f%c3%aa@example.com"))
+
+(deftest default-timeout
+  (let [mock-ftp-port 2021
+        mock-server (mock-ftp/build mock-ftp-port mock-ftp/control-connection-timeout)]
+    (.start mock-server)
+    (with-ftp [client (str "ftp://username:password@localhost:" mock-ftp-port) :default-timeout-ms 200]
+      (is (thrown? java.io.IOException (client-file-names client))))
+    (.stop mock-server)))

--- a/test/miner/mock_ftp.clj
+++ b/test/miner/mock_ftp.clj
@@ -1,0 +1,24 @@
+(ns miner.mock-ftp
+  (:import
+    (org.mockftpserver.fake UserAccount)
+    (org.mockftpserver.fake.filesystem UnixFakeFileSystem DirectoryEntry)
+    (org.mockftpserver.fake.command AbstractFakeCommandHandler)
+    (org.mockftpserver.core.command CommandNames)
+    (org.mockftpserver.fake FakeFtpServer)))
+
+(def control-connection-timeout
+  (-> (proxy [AbstractFakeCommandHandler] []
+        (handle [cmd session]
+          (while true
+            (Thread/sleep 60000))))))
+
+(defn build [control-port handler]
+  (let [mock-server (new FakeFtpServer)
+        filesystem (new UnixFakeFileSystem)]
+    (.addUserAccount mock-server (new UserAccount "username" "password" "/home/username"))
+    (.add filesystem (new DirectoryEntry "/home/username"))
+    (.setFileSystem mock-server filesystem)
+
+    (.setServerControlPort mock-server control-port)
+    (.setCommandHandler mock-server CommandNames/PASV handler)
+    mock-server))


### PR DESCRIPTION
Fixes #32 
Sometimes the process gets stuck trying to read from a socket in the
getReply method.

I have changed the code so that we can pass a :default-timeout-ms
parameter (by default unset) which will throw an exception after the
desired amount of ms has been elapsed.

