### PR TITLE
fix: split mkdirs paths on Windows platform

### DIFF
--- a/src/miner/ftp.clj
+++ b/src/miner/ftp.clj
@@ -217,8 +217,12 @@
 
 ;; Regular mkdir can only make one level at a time; mkdirs makes nested paths in the correct order
 (defn client-mkdirs [client subpath]
-  (doseq [d (reductions (fn [path item] (str path File/separator item))  (fs/split subpath))]
-    (client-mkdir client d)))
+  (let [norm-path (-> subpath
+                      (str/replace #"\\" "/")
+                      (str/split #"/")
+                      (#(if (str/blank? (first %)) (cons "/" (rest %)) %)))]
+    (doseq [d (reductions (fn [path item] (str path "/" item)) norm-path)]
+      (client-mkdir client d))))
 
 (defn client-delete [client fname]
   "Delete a file (must be within a with-ftp)"


### PR DESCRIPTION
Calling mkdirs on Windows split and join path accordingly to the host platform file separator, as a result nothing is split if path is in Unix format. Also trying to accomplish and giving path with Windows file separator does not solve the problem tough the path is split it is then recombined under reductions with Windows file separator, which it not standard and might not be accepted by all the ftp servers.   