### PR TITLE
Feature/issue 40/explicit credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ pom.xml
 .lein-failures
 .lein-plugins
 .lein
+.idea
+*.iml

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.velisco/clj-ftp "0.3.17"
+(defproject com.velisco/clj-ftp "0.3.18-SNAPSHOT"
   :description "Clojure wrapper on Apache Commons Net for FTP"
   :url "http://github.com/miner/clj-ftp"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -6,10 +6,10 @@
   :min-lein-version "2.0"
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [me.raynes/fs "1.4.6"]
-                 [commons-net "3.8.0"]]
+                 [commons-net "3.9.0"]]
   :profiles {:test {:resource-paths ["test-resources"]
-                    :dependencies [[org.mockftpserver/MockFtpServer "3.0.0"]
-                                   [org.slf4j/slf4j-jdk14 "1.7.33"]
+                    :dependencies [[org.mockftpserver/MockFtpServer "3.1.0"]
+                                   [org.slf4j/slf4j-jdk14 "1.7.36"]
                                    [digest "1.4.10"]]}})
 
 

--- a/test/miner/ftp_test.clj
+++ b/test/miner/ftp_test.clj
@@ -198,3 +198,19 @@
     (with-ftp [client (str "ftp://username:password@localhost:" mock-ftp-port) :default-timeout-ms 200]
       (is (thrown? java.io.IOException (client-file-names client))))
     (.stop mock-server)))
+
+(deftest explicit-user-credentials
+  (let [mock-ftp-port 2021
+        mock-server (mock-ftp/build mock-ftp-port)]
+    (.start mock-server)
+    (with-ftp [client (str "ftp://localhost:" mock-ftp-port) :username "username" :password "password"]
+      (is (empty? (client-file-names client))))
+    (.stop mock-server)))
+
+(deftest url-user-credentials
+  (let [mock-ftp-port 2021
+        mock-server (mock-ftp/build mock-ftp-port)]
+    (.start mock-server)
+    (with-ftp [client (str "ftp://username:password@localhost:" mock-ftp-port)]
+      (is (empty? (client-file-names client))))
+    (.stop mock-server)))

--- a/test/miner/mock_ftp.clj
+++ b/test/miner/mock_ftp.clj
@@ -12,13 +12,17 @@
           (while true
             (Thread/sleep 60000))))))
 
-(defn build ^FakeFtpServer [control-port handler]
-  (let [mock-server (new FakeFtpServer)
-        filesystem (new UnixFakeFileSystem)]
-    (.addUserAccount mock-server (new UserAccount "username" "password" "/home/username"))
-    (.add filesystem (new DirectoryEntry "/home/username"))
-    (.setFileSystem mock-server filesystem)
+(defn build ^FakeFtpServer
+  ([control-port]
+   (build control-port nil))
+  ([control-port handler]
+   (let [mock-server (new FakeFtpServer)
+         filesystem (new UnixFakeFileSystem)]
+     (.addUserAccount mock-server (new UserAccount "username" "password" "/home/username"))
+     (.add filesystem (new DirectoryEntry "/home/username"))
+     (.setFileSystem mock-server filesystem)
 
-    (.setServerControlPort mock-server control-port)
-    (.setCommandHandler mock-server CommandNames/PASV handler)
-    mock-server))
+     (.setServerControlPort mock-server control-port)
+     (when handler
+       (.setCommandHandler mock-server CommandNames/PASV handler))
+     mock-server)))


### PR DESCRIPTION
As per my comment in [issue 40](https://github.com/miner/clj-ftp/issues/40#issuecomment-1465127951), here's an implementation of explicit username/password via parameters to the `with-ftp` macro.

A couple of the tests were not passing when first checking out the code base - it looks like they rely on external services that may have changed since they were written. I've not fixed those particular tests.